### PR TITLE
Fix: correct class name typo in N8nResponse

### DIFF
--- a/src/Clients/ApiClient.php
+++ b/src/Clients/ApiClient.php
@@ -87,7 +87,7 @@ class ApiClient {
      * @param string|null $entityClass
      * @return N8nResponse
      */
-    protected function wrapEntity(array $raw, ?string $entityClass = null): N8NResponse {
+    protected function wrapEntity(array $raw, ?string $entityClass = null): N8nResponse {
         $success = $raw['success'] ?? false;
 
         $data = $success && $entityClass && isset($raw['data'])
@@ -98,7 +98,7 @@ class ApiClient {
 
         $code = $raw['code'] ?? ($success ? 200:500);
 
-        return new N8NResponse($success, $data, $message, $code);
+        return new N8nResponse($success, $data, $message, $code);
     }
 
 }

--- a/src/Clients/WebhookClient.php
+++ b/src/Clients/WebhookClient.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use UsmanZahid\N8n\Enums\RequestMethod;
 use UsmanZahid\N8n\Enums\WebhookMode;
 use UsmanZahid\N8n\Helpers\RequestHelper;
-use UsmanZahid\N8n\Response\N8NResponse;
+use UsmanZahid\N8n\Response\N8nResponse;
 
 class WebhookClient {
     protected string $baseUrl;
@@ -47,9 +47,9 @@ class WebhookClient {
      *
      * @param string $webhookId The webhook ID
      * @param array $data Optional payload for the webhook
-     * @return N8NResponse
+     * @return N8nResponse
      */
-    public function send(string $webhookId, array $data = []): N8NResponse {
+    public function send(string $webhookId, array $data = []): N8nResponse {
         $url = $this->baseUrl . $this->mode->prefix() . "/$webhookId";
         $options = RequestHelper::buildOptions($this->method->value, $data, $this->basicAuth);
 
@@ -58,7 +58,7 @@ class WebhookClient {
             $body = (string) $response->getBody();
             $decoded = $body==='' ? null:(json_decode($body, true) ?? $body);
 
-            return new N8NResponse(true, $decoded, null, $response->getStatusCode());
+            return new N8nResponse(true, $decoded, null, $response->getStatusCode());
         } catch (GuzzleException $e) {
             return RequestHelper::handleException($e);
         }

--- a/src/Helpers/RequestHelper.php
+++ b/src/Helpers/RequestHelper.php
@@ -88,7 +88,7 @@ class RequestHelper {
         }
 
         return !$returnArray
-            ? new N8NResponse(false, $data, $message, $code)
+            ? new N8nResponse(false, $data, $message, $code)
             :[
                 'code' => $code,
                 'message' => $message,

--- a/tests/Unit/Clients/WebhookClientTest.php
+++ b/tests/Unit/Clients/WebhookClientTest.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\StreamInterface;
 use UsmanZahid\N8n\Clients\WebhookClient;
 use UsmanZahid\N8n\Enums\RequestMethod;
 use UsmanZahid\N8n\Enums\WebhookMode;
-use UsmanZahid\N8n\Response\N8NResponse;
+use UsmanZahid\N8n\Response\N8nResponse;
 
 class WebhookClientTest extends TestCase
 {
@@ -32,7 +32,7 @@ class WebhookClientTest extends TestCase
 
         $result = $client->send('test-webhook');
 
-        $this->assertInstanceOf(N8NResponse::class, $result);
+        $this->assertInstanceOf(N8nResponse::class, $result);
         $this->assertTrue($result->success);
         $this->assertEquals(['ok' => true], $result->data);
         $this->assertEquals(200, $result->code);


### PR DESCRIPTION
### Summary
This pull request fixes a typo in the class name `N8nResponse` that was previously written as `N8NResponse`.

### Changes
- Updated class references in:
  - src/Clients/ApiClient.php
  - src/Clients/WebhookClient.php
  - src/Helpers/RequestHelper.php

### Issue Reference
Closes #2

### Testing
- Verified that all references now use the correct class name.
- Code runs without errors in local environment.